### PR TITLE
feat: Add Gemini support as alternative AI provider

### DIFF
--- a/Sources/Models/AIProvider.swift
+++ b/Sources/Models/AIProvider.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+/// Supported AI providers for classification
+enum AIProvider: String, CaseIterable, Identifiable {
+    case claude = "Claude"
+    case gemini = "Gemini"
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .claude: return "Claude (Anthropic)"
+        case .gemini: return "Gemini (Google)"
+        }
+    }
+
+    var costInfo: String {
+        switch self {
+        case .claude:
+            return "파일당 약 $0.002 (Haiku 4.5)"
+        case .gemini:
+            return "무료 티어: 분당 15회, 일 1500회"
+        }
+    }
+
+    var keyPlaceholder: String {
+        switch self {
+        case .claude: return "sk-ant-..."
+        case .gemini: return "AIza..."
+        }
+    }
+
+    var keyPrefix: String {
+        switch self {
+        case .claude: return "sk-ant-"
+        case .gemini: return "AIza"
+        }
+    }
+
+    func hasAPIKey() -> Bool {
+        switch self {
+        case .claude:
+            return KeychainService.getAPIKey() != nil
+        case .gemini:
+            return KeychainService.getGeminiAPIKey() != nil
+        }
+    }
+
+    func saveAPIKey(_ key: String) -> Bool {
+        switch self {
+        case .claude:
+            return KeychainService.saveAPIKey(key)
+        case .gemini:
+            return KeychainService.saveGeminiAPIKey(key)
+        }
+    }
+
+    func deleteAPIKey() {
+        switch self {
+        case .claude:
+            KeychainService.deleteAPIKey()
+        case .gemini:
+            KeychainService.deleteGeminiAPIKey()
+        }
+    }
+}

--- a/Sources/Services/AIService.swift
+++ b/Sources/Services/AIService.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+/// Provider-agnostic AI service that routes to Claude or Gemini
+actor AIService {
+    private let claudeClient = ClaudeAPIClient()
+    private let geminiClient = GeminiAPIClient()
+
+    /// Current provider (read from UserDefaults)
+    private var currentProvider: AIProvider {
+        if let saved = UserDefaults.standard.string(forKey: "selectedProvider"),
+           let provider = AIProvider(rawValue: saved) {
+            return provider
+        }
+        return .gemini
+    }
+
+    // MARK: - Model Names
+
+    var fastModel: String {
+        switch currentProvider {
+        case .claude:
+            return ClaudeAPIClient.haikuModel
+        case .gemini:
+            return GeminiAPIClient.flashModel
+        }
+    }
+
+    var preciseModel: String {
+        switch currentProvider {
+        case .claude:
+            return ClaudeAPIClient.sonnetModel
+        case .gemini:
+            return GeminiAPIClient.proModel
+        }
+    }
+
+    // MARK: - API Call
+
+    /// Send a message using the current provider
+    func sendMessage(
+        model: String,
+        maxTokens: Int,
+        userMessage: String
+    ) async throws -> String {
+        switch currentProvider {
+        case .claude:
+            return try await claudeClient.sendMessage(
+                model: model,
+                maxTokens: maxTokens,
+                userMessage: userMessage
+            )
+        case .gemini:
+            return try await geminiClient.sendMessage(
+                model: model,
+                maxTokens: maxTokens,
+                userMessage: userMessage
+            )
+        }
+    }
+
+    /// Send using the fast model (Haiku / Flash)
+    func sendFast(maxTokens: Int = 4096, message: String) async throws -> String {
+        try await sendMessage(model: fastModel, maxTokens: maxTokens, userMessage: message)
+    }
+
+    /// Send using the precise model (Sonnet / Pro)
+    func sendPrecise(maxTokens: Int = 2048, message: String) async throws -> String {
+        try await sendMessage(model: preciseModel, maxTokens: maxTokens, userMessage: message)
+    }
+}

--- a/Sources/Services/Gemini/GeminiAPIClient.swift
+++ b/Sources/Services/Gemini/GeminiAPIClient.swift
@@ -1,0 +1,165 @@
+import Foundation
+
+/// URLSession-based Google Gemini API client
+actor GeminiAPIClient {
+    private let baseURL = "https://generativelanguage.googleapis.com/v1beta/models"
+    private let session: URLSession
+
+    init() {
+        let config = URLSessionConfiguration.default
+        config.timeoutIntervalForRequest = 60
+        config.timeoutIntervalForResource = 120
+        self.session = URLSession(configuration: config)
+    }
+
+    // MARK: - Models
+
+    static let flashModel = "gemini-2.0-flash"
+    static let proModel = "gemini-1.5-pro"
+
+    // MARK: - Request/Response Types
+
+    struct GenerateContentRequest: Encodable {
+        let contents: [Content]
+        let generationConfig: GenerationConfig?
+
+        struct Content: Encodable {
+            let parts: [Part]
+            let role: String?
+
+            struct Part: Encodable {
+                let text: String
+            }
+        }
+
+        struct GenerationConfig: Encodable {
+            let maxOutputTokens: Int?
+            let temperature: Double?
+        }
+    }
+
+    struct GenerateContentResponse: Decodable {
+        let candidates: [Candidate]?
+        let error: APIError?
+
+        struct Candidate: Decodable {
+            let content: Content?
+
+            struct Content: Decodable {
+                let parts: [Part]?
+
+                struct Part: Decodable {
+                    let text: String?
+                }
+            }
+        }
+
+        struct APIError: Decodable {
+            let code: Int?
+            let message: String?
+            let status: String?
+        }
+
+        var text: String {
+            candidates?
+                .first?
+                .content?
+                .parts?
+                .compactMap { $0.text }
+                .joined() ?? ""
+        }
+    }
+
+    // MARK: - API Call
+
+    /// Send a message to Gemini and get the text response
+    func sendMessage(
+        model: String,
+        maxTokens: Int,
+        userMessage: String
+    ) async throws -> String {
+        guard let apiKey = KeychainService.getGeminiAPIKey() else {
+            throw GeminiAPIError.noAPIKey
+        }
+
+        let endpoint = "\(baseURL)/\(model):generateContent?key=\(apiKey)"
+
+        guard let url = URL(string: endpoint) else {
+            throw GeminiAPIError.invalidURL
+        }
+
+        let request = GenerateContentRequest(
+            contents: [
+                .init(
+                    parts: [.init(text: userMessage)],
+                    role: "user"
+                )
+            ],
+            generationConfig: .init(
+                maxOutputTokens: maxTokens,
+                temperature: 0.7
+            )
+        )
+
+        var urlRequest = URLRequest(url: url)
+        urlRequest.httpMethod = "POST"
+        urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        let encoder = JSONEncoder()
+        urlRequest.httpBody = try encoder.encode(request)
+
+        let (data, response) = try await session.data(for: urlRequest)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw GeminiAPIError.invalidResponse
+        }
+
+        let geminiResponse = try JSONDecoder().decode(GenerateContentResponse.self, from: data)
+
+        if let error = geminiResponse.error {
+            throw GeminiAPIError.apiError(
+                status: error.code ?? httpResponse.statusCode,
+                message: error.message ?? "Unknown error"
+            )
+        }
+
+        if httpResponse.statusCode != 200 {
+            throw GeminiAPIError.httpError(status: httpResponse.statusCode)
+        }
+
+        let text = geminiResponse.text
+        if text.isEmpty {
+            throw GeminiAPIError.emptyResponse
+        }
+
+        return text
+    }
+}
+
+// MARK: - Errors
+
+enum GeminiAPIError: LocalizedError {
+    case noAPIKey
+    case invalidURL
+    case invalidResponse
+    case emptyResponse
+    case httpError(status: Int)
+    case apiError(status: Int, message: String)
+
+    var errorDescription: String? {
+        switch self {
+        case .noAPIKey:
+            return "Gemini API 키가 설정되지 않았습니다"
+        case .invalidURL:
+            return "잘못된 URL"
+        case .invalidResponse:
+            return "잘못된 응답"
+        case .emptyResponse:
+            return "빈 응답"
+        case .httpError(let status):
+            return "HTTP 오류: \(status)"
+        case .apiError(_, let message):
+            return message
+        }
+    }
+}

--- a/Sources/Services/KeychainService.swift
+++ b/Sources/Services/KeychainService.swift
@@ -4,20 +4,50 @@ import Security
 /// Secure storage for API keys using macOS Keychain
 enum KeychainService {
     private static let service = "com.hwaa.ai-pkm-menubar"
-    private static let apiKeyAccount = "anthropic-api-key"
+    private static let claudeKeyAccount = "anthropic-api-key"
+    private static let geminiKeyAccount = "gemini-api-key"
 
-    // MARK: - API Key
+    // MARK: - Claude API Key (legacy compatibility)
 
     static func saveAPIKey(_ key: String) -> Bool {
-        // Delete existing first
-        deleteAPIKey()
+        saveKey(key, account: claudeKeyAccount)
+    }
+
+    static func getAPIKey() -> String? {
+        getKey(account: claudeKeyAccount)
+    }
+
+    @discardableResult
+    static func deleteAPIKey() -> Bool {
+        deleteKey(account: claudeKeyAccount)
+    }
+
+    // MARK: - Gemini API Key
+
+    static func saveGeminiAPIKey(_ key: String) -> Bool {
+        saveKey(key, account: geminiKeyAccount)
+    }
+
+    static func getGeminiAPIKey() -> String? {
+        getKey(account: geminiKeyAccount)
+    }
+
+    @discardableResult
+    static func deleteGeminiAPIKey() -> Bool {
+        deleteKey(account: geminiKeyAccount)
+    }
+
+    // MARK: - Generic Key Operations
+
+    private static func saveKey(_ key: String, account: String) -> Bool {
+        deleteKey(account: account)
 
         guard let data = key.data(using: .utf8) else { return false }
 
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,
-            kSecAttrAccount as String: apiKeyAccount,
+            kSecAttrAccount as String: account,
             kSecValueData as String: data,
             kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlocked,
         ]
@@ -26,11 +56,11 @@ enum KeychainService {
         return status == errSecSuccess
     }
 
-    static func getAPIKey() -> String? {
+    private static func getKey(account: String) -> String? {
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,
-            kSecAttrAccount as String: apiKeyAccount,
+            kSecAttrAccount as String: account,
             kSecReturnData as String: true,
             kSecMatchLimit as String: kSecMatchLimitOne,
         ]
@@ -48,11 +78,11 @@ enum KeychainService {
     }
 
     @discardableResult
-    static func deleteAPIKey() -> Bool {
+    private static func deleteKey(account: String) -> Bool {
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,
-            kSecAttrAccount as String: apiKeyAccount,
+            kSecAttrAccount as String: account,
         ]
 
         let status = SecItemDelete(query as CFDictionary)

--- a/Sources/UI/Components/APIKeyInputView.swift
+++ b/Sources/UI/Components/APIKeyInputView.swift
@@ -3,8 +3,10 @@ import SwiftUI
 /// Reusable API key input component used in Onboarding and Settings
 struct APIKeyInputView: View {
     @EnvironmentObject var appState: AppState
-    @State private var apiKeyInput: String = ""
-    @State private var showingAPIKey: Bool = false
+    @State private var claudeKeyInput: String = ""
+    @State private var geminiKeyInput: String = ""
+    @State private var showingClaudeKey: Bool = false
+    @State private var showingGeminiKey: Bool = false
     @State private var saveMessage: String = ""
 
     /// Whether to show the delete button when a key exists
@@ -13,69 +15,144 @@ struct APIKeyInputView: View {
     var onSaved: (() -> Void)?
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text("Claude API Key")
-                .font(.subheadline)
-                .fontWeight(.medium)
+        VStack(alignment: .leading, spacing: 12) {
+            // Provider Selection
+            VStack(alignment: .leading, spacing: 6) {
+                Text("AI 제공자")
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+
+                Picker("", selection: $appState.selectedProvider) {
+                    ForEach(AIProvider.allCases) { provider in
+                        Text(provider.displayName).tag(provider)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .labelsHidden()
+            }
+
+            Divider()
+
+            // Gemini API Key
+            apiKeySection(
+                title: "Gemini API Key",
+                keyInput: $geminiKeyInput,
+                showingKey: $showingGeminiKey,
+                provider: .gemini,
+                hasKey: appState.hasGeminiKey
+            )
+
+            // Claude API Key
+            apiKeySection(
+                title: "Claude API Key",
+                keyInput: $claudeKeyInput,
+                showingKey: $showingClaudeKey,
+                provider: .claude,
+                hasKey: appState.hasClaudeKey
+            )
+
+            // Current provider status
+            if appState.hasAPIKey {
+                Label("\(appState.selectedProvider.displayName) 사용 중", systemImage: "checkmark.circle.fill")
+                    .font(.caption)
+                    .foregroundColor(.green)
+            } else {
+                Label("\(appState.selectedProvider.displayName) API 키 필요", systemImage: "exclamationmark.triangle.fill")
+                    .font(.caption)
+                    .foregroundColor(.orange)
+            }
+        }
+        .onAppear {
+            if appState.hasClaudeKey {
+                claudeKeyInput = "••••••••"
+            }
+            if appState.hasGeminiKey {
+                geminiKeyInput = "••••••••"
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func apiKeySection(
+        title: String,
+        keyInput: Binding<String>,
+        showingKey: Binding<Bool>,
+        provider: AIProvider,
+        hasKey: Bool
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Text(title)
+                    .font(.caption)
+                    .fontWeight(.medium)
+
+                if hasKey {
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundColor(.green)
+                        .font(.caption)
+                }
+
+                if provider == appState.selectedProvider {
+                    Text("(활성)")
+                        .font(.caption2)
+                        .foregroundColor(.blue)
+                }
+            }
 
             HStack {
-                if showingAPIKey {
-                    TextField("sk-ant-...", text: $apiKeyInput)
+                if showingKey.wrappedValue {
+                    TextField(provider.keyPlaceholder, text: keyInput)
                         .textFieldStyle(.roundedBorder)
-                        .font(.system(.body, design: .monospaced))
+                        .font(.system(.caption, design: .monospaced))
                 } else {
-                    SecureField("sk-ant-...", text: $apiKeyInput)
+                    SecureField(provider.keyPlaceholder, text: keyInput)
                         .textFieldStyle(.roundedBorder)
+                        .font(.caption)
                 }
 
-                Button(action: { showingAPIKey.toggle() }) {
-                    Image(systemName: showingAPIKey ? "eye.slash" : "eye")
+                Button(action: { showingKey.wrappedValue.toggle() }) {
+                    Image(systemName: showingKey.wrappedValue ? "eye.slash" : "eye")
                 }
                 .buttonStyle(.plain)
+                .font(.caption)
             }
 
             HStack {
                 Button("저장") {
-                    if apiKeyInput.hasPrefix("sk-ant-") {
-                        let saved = KeychainService.saveAPIKey(apiKeyInput)
-                        saveMessage = saved ? "저장 완료" : "저장 실패"
-                        appState.hasAPIKey = saved
-                        if saved { onSaved?() }
-                    } else {
-                        saveMessage = "유효한 API 키를 입력하세요"
-                    }
+                    saveKey(keyInput.wrappedValue, provider: provider)
                 }
-                .buttonStyle(.borderedProminent)
-                .controlSize(.small)
+                .buttonStyle(.bordered)
+                .controlSize(.mini)
+                .disabled(keyInput.wrappedValue.isEmpty || keyInput.wrappedValue == "••••••••")
 
-                if showDeleteButton && appState.hasAPIKey {
+                if showDeleteButton && hasKey {
                     Button("삭제") {
-                        KeychainService.deleteAPIKey()
-                        apiKeyInput = ""
-                        appState.hasAPIKey = false
+                        provider.deleteAPIKey()
+                        keyInput.wrappedValue = ""
+                        appState.updateAPIKeyStatus()
                         saveMessage = "삭제됨"
                     }
                     .buttonStyle(.bordered)
-                    .controlSize(.small)
+                    .controlSize(.mini)
                 }
 
                 if !saveMessage.isEmpty {
                     Text(saveMessage)
-                        .font(.caption)
+                        .font(.caption2)
                         .foregroundColor(saveMessage == "저장 완료" ? .green : .orange)
                 }
             }
-
-            if appState.hasAPIKey {
-                Label("API 키 저장됨 (Keychain)", systemImage: "checkmark.circle.fill")
-                    .font(.caption)
-                    .foregroundColor(.green)
-            }
         }
-        .onAppear {
-            if appState.hasAPIKey {
-                apiKeyInput = "••••••••"
-            }
+    }
+
+    private func saveKey(_ key: String, provider: AIProvider) {
+        if key.hasPrefix(provider.keyPrefix) {
+            let saved = provider.saveAPIKey(key)
+            saveMessage = saved ? "저장 완료" : "저장 실패"
+            appState.updateAPIKeyStatus()
+            if saved { onSaved?() }
+        } else {
+            saveMessage = "유효한 \(provider.rawValue) API 키를 입력하세요"
         }
     }
 }

--- a/Sources/UI/OnboardingView.swift
+++ b/Sources/UI/OnboardingView.swift
@@ -119,22 +119,32 @@ struct OnboardingView: View {
                 .font(.title3)
                 .fontWeight(.semibold)
 
-            Text("파일 분류에 Claude AI를 사용합니다")
+            Text("파일 분류에 AI를 사용합니다")
                 .font(.subheadline)
                 .foregroundColor(.secondary)
 
             // API key guide link
             Button(action: {
-                if let url = URL(string: "https://console.anthropic.com/settings/keys") {
-                    NSWorkspace.shared.open(url)
+                let url: URL
+                if appState.selectedProvider == .gemini {
+                    url = URL(string: "https://aistudio.google.com/apikey")!
+                } else {
+                    url = URL(string: "https://console.anthropic.com/settings/keys")!
                 }
+                NSWorkspace.shared.open(url)
             }) {
                 HStack(spacing: 4) {
                     Text("API 키가 없다면?")
                         .font(.caption)
-                    Text("console.anthropic.com에서 발급")
-                        .font(.caption)
-                        .underline()
+                    if appState.selectedProvider == .gemini {
+                        Text("aistudio.google.com에서 발급 (무료)")
+                            .font(.caption)
+                            .underline()
+                    } else {
+                        Text("console.anthropic.com에서 발급")
+                            .font(.caption)
+                            .underline()
+                    }
                 }
                 .foregroundColor(.secondary)
             }
@@ -144,12 +154,21 @@ struct OnboardingView: View {
                 .padding(.horizontal, 24)
 
             VStack(alignment: .leading, spacing: 2) {
-                Text("* Claude 구독과 별도로 API 결제 등록이 필요합니다")
-                    .font(.caption)
-                    .foregroundColor(.orange)
-                Text("파일당 약 $0.002 (Haiku) / 불확실 시 ~$0.01 (Sonnet)")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
+                if appState.selectedProvider == .gemini {
+                    Text("💡 Gemini는 무료 티어로 시작 가능")
+                        .font(.caption)
+                        .foregroundColor(.green)
+                    Text("분당 15회, 일 1500회 무료")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                } else {
+                    Text("* Claude 구독과 별도로 API 결제 등록이 필요합니다")
+                        .font(.caption)
+                        .foregroundColor(.orange)
+                    Text("파일당 약 $0.002 (Haiku) / 불확실 시 ~$0.01 (Sonnet)")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
             }
             .padding(.horizontal, 24)
 

--- a/Sources/UI/SettingsView.swift
+++ b/Sources/UI/SettingsView.swift
@@ -83,12 +83,18 @@ struct SettingsView: View {
                 Text("비용 안내")
                     .font(.subheadline)
                     .fontWeight(.medium)
-                Text("파일당 약 $0.002 (Haiku 4.5)")
+                Text(appState.selectedProvider.costInfo)
                     .font(.caption)
                     .foregroundColor(.secondary)
-                Text("불확실한 파일은 Sonnet 4.5로 재분류 (약 $0.01)")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
+                if appState.selectedProvider == .claude {
+                    Text("불확실한 파일은 Sonnet 4.5로 재분류 (약 $0.01)")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                } else {
+                    Text("불확실한 파일은 Gemini Pro로 재분류")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
             }
 
             Spacer()


### PR DESCRIPTION
## 변경 사항

### 새로운 기능
- **Gemini 지원**: Google의 Generative AI API 연동
- **Provider 선택**: Settings에서 Claude/Gemini 중 선택 가능
- **무료 티어**: Gemini는 카드 등록 없이 무료로 시작 가능

### 파일 변경
- `GeminiAPIClient.swift`: Gemini API 클라이언트
- `AIProvider.swift`: Provider enum (Claude/Gemini)
- `AIService.swift`: Provider 통합 서비스
- `KeychainService.swift`: Provider별 API 키 저장
- `Classifier.swift`: AIService 사용으로 변경
- `SettingsView.swift`: Provider 선택 UI
- `OnboardingView.swift`: Provider별 안내 문구

### Gemini 장점
- 무료 티어: 분당 15회, 일 1500회
- 카드 등록 불필요
- Flash(빠름) / Pro(정밀) 모델 지원

### 기본값
- 새 설치시 Gemini가 기본값 (무료 시작 가능)
- 기존 Claude 사용자는 그대로 유지됨